### PR TITLE
more efficent ports method for windows

### DIFF
--- a/source/serialport/port.d
+++ b/source/serialport/port.d
@@ -349,20 +349,13 @@ public:
             }
             version (Windows)
             {
+                import std.windows.registry;
                 string[] ret;
-                enum pre = `\\.\COM`;
-                foreach (int n; 0 .. 255)
-                {
-                    auto i = n+1;
-                    HANDLE p = CreateFileA(text(pre, i).toStringz,
-                            GENERIC_READ | GENERIC_WRITE, 0, null,
-                                           OPEN_EXISTING, 0, null);
-                    if (p != INVALID_HANDLE_VALUE)
-                    {
-                        ret ~= text("COM", i);
-                        CloseHandle(p);
-                    }
-                }
+                auto coms = Registry.localMachine().getKey("HARDWARE").getKey("DEVICEMAP").getKey("SERIALCOMM").values;
+                ret.length = coms.count;
+                for (int i=0;i< ret.length;i++) {
+                    ret[i]=coms[i].value_SZ;
+                }   
                 return ret;
             }
         }
@@ -613,3 +606,10 @@ protected:
 }
 
 private bool hasFlag(A,B)(A a, B b) @property { return (a & b) == b; }
+
+unittest{
+    import std.stdio;
+    foreach(  e ;SerialPort.ports()   ){
+        std.stdio.writeln(e);
+    }
+}


### PR DESCRIPTION
It seems to be more efficient to get a list from the windows registry. 
As I tested, newly insted USB device was updated correctly before read registry on windows 10.
